### PR TITLE
Fix socket cleanup in http2 detection

### DIFF
--- a/wafmap/http2_detection.py
+++ b/wafmap/http2_detection.py
@@ -24,6 +24,7 @@ def detect_http2(url: str, port: int = 443, timeout: float = 5.0, debug: bool = 
         } if debug else None
     }
 
+    sock: Optional[socket.socket] = None
     try:
         # Extract hostname
         hostname = urlparse(url).hostname or url.split('//')[-1].split('/')[0]
@@ -59,6 +60,7 @@ def detect_http2(url: str, port: int = 443, timeout: float = 5.0, debug: bool = 
         return result
 
     finally:
-        sock.close()
+        if sock:
+            sock.close()
     
     return result


### PR DESCRIPTION
## Summary
- prevent `sock` from being undefined if connection fails
- only close the socket if it was created

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845119e1840832ca84c38dd84113f06